### PR TITLE
Tunable dispatch batch limit via sysfs

### DIFF
--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -3000,7 +3000,7 @@ static ssize_t qos_batch_limit_store(struct device *dev,
 
 	if (kstrtouint(buf, 10, &val) < 0)
 		return -EINVAL;
-	if (val < 1 || val > 256)
+	if (val < 1)
 		return -EINVAL;
 
 	ndev->qos_batch_limit = val;


### PR DESCRIPTION
Closes #55.

  - Replace hardcoded `NVME_QOS_MAX_BATCH` (4) with a runtime-tunable per-controller sysfs knob (`qos_batch_limit`)
  - Configurable range 1–256, default 4 preserves current behavior
    - 256 is way higher than we will need, I'm going to guess that we will get deminishing returns after 32 due to lock hold times but I'm not confident. Higher range for more flexibility later. 
  - Takes effect immediately on both `nvme_qos_kick()` and `nvme_queue_rq()` dispatch paths