### PR TITLE
Privatized Priority List Nodes by Moving Them Into `struct nvme_iod`

### DIFF
--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -1791,6 +1791,7 @@ static void nvme_pci_complete_rq(struct request *req)
 		if (!list_empty(&iod->qos_node))
 			list_del_init(&iod->qos_node);
 		spin_unlock_irqrestore(&nvmeq->sq_lock, flags);
+	}
 #endif
 	nvme_pci_unmap_rq(req);
 	nvme_complete_rq(req);


### PR DESCRIPTION
Closes #28 

Previously nodes in the high/normal priority lists contained `queuelist` items found in `struct request`. This caused a potential security risk, since those structures are open to the rest of the kernel. This issue moves them into `struct nvme_iod` which is localized to a single I/O request. This is more semantically in-line with the purpose of these nodes and their containing struct while increasing their usage safety.

A guard was also placed inside the nvme's pci complete callback, `nvme_pci_complete_rq()` to make sure initialized qos_nodes got unlinked from the lists in the event of a cancel/timeout/reset.