### PR TITLE
Rewrite the refill algorithm changing to time-based bucked refill

### DIFF
--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -4,7 +4,6 @@
  * Copyright (c) 2011-2014, Intel Corporation.
  */
 
-#include "asm-generic/rwonce.h"
 #include <linux/acpi.h>
 #include <linux/async.h>
 #include <linux/blkdev.h>


### PR DESCRIPTION
Please merge PR #65 before review this PR since it is built upon it

# **Summary**
Replaces the legacy "reset-when-empty" credit logic with a time-based Token Bucket scheduler to provide accurate traffic shaping and bandwidth guarantees for NVMe QoS.

# **Problem**
The previous implementation simply reset high_credits to the maximum value immediately upon depletion. This failed to enforce a sustained I/O rate, allowing High priority traffic to burst continuously (limited only by submission speed) and potentially starve Normal traffic under contention.

# **Solution**
Implemented a true O(1) Token Bucket algorithm where tokens are refilled based on elapsed time (jiffies) rather than completion events.

- Time-Based Refill: Tokens are added proportional to the time passed since the last submission (delta * rate).
- Burst Cap: The bucket size is capped at the configured rate to prevent unbounded bursting.
- Idle Protection: Implemented a "Time Banking" fix that advances the refill clock even when the bucket is full, preventing the accumulation of massive bursts during idle periods.