### PR TITLE
Update lint to show line number errors

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -74,9 +74,9 @@ function run_checkpatch() {
 		echo -e "[${GREEN}ok${NC}]"
 	else
 		echo -e "[${RED}FAIL${NC}] ($errors errors)"
-		echo "$log" | grep -E "^ERROR:" | head -20
 		echo ""
-		echo "Run './scripts/checkpatch.pl --no-tree <patch>' for full output"
+		echo "$log"
+		echo ""
 		FAILED=1
 	fi
 }


### PR DESCRIPTION
Previously the commit hook would not display line numbers for errors that need to be corrected. This has been updated to display output more in-line with the way the CI GitHub action provides feedback:

```
ERROR: space required before the open brace '{'
#30: FILE: drivers/nvme/host/pci.c:1298:
+	if(delta && nvmeq->high_tokens < cap){

ERROR: space required before the open parenthesis '('
#30: FILE: drivers/nvme/host/pci.c:1298:
+	if(delta && nvmeq->high_tokens < cap){

ERROR: spaces prohibited around that '->' (ctx:WxW)
#33: FILE: drivers/nvme/host/pci.c:1301:
+		nvmeq -> high_tokens += new_tokens;
 		      ^

total: 3 errors, 0 warnings, 106 lines checked

NOTE: For some of the reported defects, checkpatch may be able to
      mechanically convert to the typical style using --fix or --fix-inplace.

/tmp/pr.patch has style problems, please review.

NOTE: If any of the errors are false positives, please report
      them to the maintainer, see CHECKPATCH in MAINTAINERS.
```