### PR TITLE
Add `qos_max_depth` sysfs knob to cap per-queue dispatch depth

### DIFF
--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -200,6 +200,7 @@ struct nvme_dev {
 	unsigned int qos_bypass_exit_threshold;
 	unsigned int qos_bypass_enter_ms;
 	unsigned int qos_bypass_exit_ms;
+	unsigned int qos_max_depth;    /* 0 = use full q_depth */
 #endif
 
 	struct nvme_descriptor_pools descriptor_pools[];
@@ -1429,7 +1430,9 @@ reset:
  */
 static void nvme_qos_dispatch(struct nvme_queue *nvmeq, bool commit)
 {
-	unsigned int depth = nvmeq->q_depth - 1;
+	unsigned int max_depth = nvmeq->dev->qos_max_depth;
+	unsigned int depth = (max_depth && max_depth < nvmeq->q_depth)
+				? max_depth : nvmeq->q_depth - 1;
 	unsigned int submitted = 0;
 	bool high_prio_submitted = false;
 
@@ -3147,6 +3150,31 @@ static ssize_t qos_weight_store(struct device *dev, struct device_attribute *att
 }
 static DEVICE_ATTR_RW(qos_weight);
 
+static ssize_t qos_max_depth_show(struct device *dev,
+				  struct device_attribute *attr, char *buf)
+{
+	struct nvme_dev *ndev = to_nvme_dev(dev_get_drvdata(dev));
+
+	return sysfs_emit(buf, "%u\n", ndev->qos_max_depth);
+}
+
+static ssize_t qos_max_depth_store(struct device *dev,
+				   struct device_attribute *attr,
+				   const char *buf, size_t count)
+{
+	struct nvme_dev *ndev = to_nvme_dev(dev_get_drvdata(dev));
+	unsigned int val;
+
+	if (kstrtouint(buf, 10, &val) < 0)
+		return -EINVAL;
+
+	WRITE_ONCE(ndev->qos_max_depth, val);
+	dev_info(dev, "NVMe QoS: max depth set to %u (%s)\n",
+		 val, val ? "depth-limited" : "full SQ depth");
+	return count;
+}
+static DEVICE_ATTR_RW(qos_max_depth);
+
 static ssize_t qos_bypass_enter_threshold_show(struct device *dev,
 					       struct device_attribute *attr,
 					       char *buf)
@@ -3307,6 +3335,7 @@ static struct attribute *nvme_pci_attrs[] = {
 	&dev_attr_qos_bypass_exit_threshold.attr,
 	&dev_attr_qos_bypass_enter_ms.attr,
 	&dev_attr_qos_bypass_exit_ms.attr,
+	&dev_attr_qos_max_depth.attr,
 #endif
 	NULL,
 };


### PR DESCRIPTION
Closes #77.

###  Background

  On fast NVMe drives, the hardware submission queue can be thousands of entries deep (up to 16,384 per queue). Under typical workloads, requests drain from the host priority lists faster than they accumulate, so WRR rarely gets the opportunity to arbitrate between High and Normal traffic. In this regime, p99 latency differences are negligible not because the scheduler is wrong, but because host-side contention never builds — the device side is doing all the queuing.

  This makes it difficult to benchmark or validate the QoS scheduler's effect in isolation.

 ### Problem

  Without host-side queueing pressure, nvme_qos_dispatch and nvme_qos_kick are called infrequently and operate on lists that are almost always empty. The WRR token bucket has nothing to arbitrate, and tail latency measurements are dominated by hardware scheduling behavior rather than the host QoS policy.

###  Design Tradeoff

  Capping dispatch depth forces host-side queueing at the cost of throughput and mean latency. At a cap of 8–16, the device's internal parallelism is partially underutilized, which trades peak IOPS for stable, predictable tail-latency isolation. This is the intended tradeoff, the knob is a benchmarking and tuning aid, not a production default.