### PR TITLE
Flush QoS lists safely

### DIFF
--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -1275,13 +1275,22 @@ static int nvme_qos_drain_queue_locked(struct nvme_queue *nvmeq)
  */
 static void nvme_qos_purge_queue_locked(struct nvme_queue *nvmeq)
 {
-	struct request *req, *tmp;
+	struct nvme_iod *iod, *tmp;
 
-	list_for_each_entry_safe(req, tmp, &nvmeq->high_prio_list, queuelist)
-		list_del_init(&req->queuelist);
+	list_for_each_entry_safe(iod, tmp, &nvmeq->high_prio_list, qos_node)
+		list_del_init(&iod->qos_node);
 
-	list_for_each_entry_safe(req, tmp, &nvmeq->normal_prio_list, queuelist)
-		list_del_init(&req->queuelist);
+	list_for_each_entry_safe(iod, tmp, &nvmeq->normal_prio_list, qos_node)
+		list_del_init(&iod->qos_node);
+}
+
+static void nvme_qos_purge_queue(struct nvme_queue *nvmeq)
+{
+	unsigned long flags;
+
+	spin_lock_irqsave(&nvmeq->sq_lock, flags);
+	nvme_qos_purge_queue_locked(nvmeq);
+	spin_unlock_irqrestore(&nvmeq->sq_lock, flags);
 }
 
 /*
@@ -1337,50 +1346,6 @@ static void nvme_qos_drain_all_queues(struct nvme_dev *dev)
  * Queued but not submitted requests need to be failed during the
  * controller reset/queue reinit for consistent request handling
  */
-
-static void nvme_qos_fail_queued_requests(struct nvme_queue *nvmeq)
-{
-	LIST_HEAD(local);
-	/* Move all pending requests from the queue to a local list to minimize lock hold time */
-	struct request *req;
-	unsigned long flags;
-
-	/* Process high priority list and low priority list */
-	spin_lock_irqsave(&nvmeq->sq_lock, flags);
-	list_splice_init(&nvmeq->high_prio_list, &local);
-	list_splice_init(&nvmeq->normal_prio_list, &local);
-	spin_unlock_irqrestore(&nvmeq->sq_lock, flags);
-
-	while (!list_empty(&local)) {
-		req = list_first_entry(&local, struct request, queuelist);
-		list_del_init(&req->queuelist);
-		nvme_req(req)->status = NVME_SC_HOST_ABORTED_CMD;
-		nvme_req(req)->flags |= NVME_REQ_CANCELLED;
-		blk_mq_complete_request(req);
-	}
-}
-
-/*
- * Fail queued but not submitted requests from the queues
- * Called during the controller reset/queue reinit for consistent request handling
- */
-
-static void nvme_qos_fail_all_queued_requests(struct nvme_dev *dev)
-{
-	unsigned int i;
-
-	/* Process all queues */
-	for (i = 0; i < dev->ctrl.queue_count; i++) {
-
-		/* Obtain the queue structure for the current queue index */
-		struct nvme_queue *nvmeq = &dev->queues[i];
-
-		if (!nvmeq->sq_cmds)
-			continue; /* Skip queues that are not initialized */
-
-		nvme_qos_fail_queued_requests(nvmeq);
-	}
-}
 
 static bool nvme_qos_is_high_prio(struct request *req)
 {
@@ -2461,20 +2426,19 @@ static void nvme_free_queues(struct nvme_dev *dev, int lowest)
 	int i;
 
 	for (i = dev->ctrl.queue_count - 1; i >= lowest; i--) {
+#ifdef CONFIG_NVME_QOS
 		struct nvme_queue *nvmeq = &dev->queues[i];
 
-#ifdef CONFIG_NVME_QOS
 		/*
-		 * Requests queued in the QoS lists haven't been submitted to HW
-		 * yet, so they won't be handled by nvme_cancel_request().  Fail
-		 * them explicitly before freeing queue memory.
+		 * Requests queued in QoS lists are not submitted to hardware.
+		 * Purge them before freeing queue memory.
 		 */
 		if (nvmeq->sq_cmds)
-			nvme_qos_fail_queued_requests(nvmeq);
+			nvme_qos_purge_queue(nvmeq);
 #endif
 
 		dev->ctrl.queue_count--;
-		nvme_free_queue(nvmeq);
+		nvme_free_queue(&dev->queues[i]);
 	}
 }
 
@@ -2488,20 +2452,18 @@ static void nvme_suspend_queue(struct nvme_dev *dev, unsigned int qid)
 	/* ensure that nvme_queue_rq() sees NVMEQ_ENABLED cleared */
 	mb();
 
+	nvmeq->dev->online_queues--;
+
 	/*
-	 * Quiesce admin queue before completing any QoS-queued requests from it.
+	 * Quiesce admin queue before purging any QoS-queued requests from it.
 	 */
 	if (!nvmeq->qid && nvmeq->dev->ctrl.admin_q)
 		nvme_quiesce_admin_queue(&nvmeq->dev->ctrl);
 
 #ifdef CONFIG_NVME_QOS
-	/* Fail queued but not submitted requests before
-	 * suspending to avoid stalling on a frozen queue
-	 */
-	nvme_qos_fail_queued_requests(nvmeq);
+	nvme_qos_purge_queue(nvmeq);
 #endif
 
-	nvmeq->dev->online_queues--;
 	if (!test_and_clear_bit(NVMEQ_POLLED, &nvmeq->flags))
 		pci_free_irq(to_pci_dev(dev->dev), nvmeq->cq_vector, nvmeq);
 }
@@ -4146,24 +4108,8 @@ static void nvme_reset_work(struct work_struct *work)
 	 * If we're called to reset a live controller first shut it down before
 	 * moving on.
 	 */
-#ifdef CONFIG_NVME_QOS
-
-	if (dev->ctrl.ctrl_config & NVME_CC_ENABLE) {
-
-		/* Fail any queued requests before disable to avoid blocking shutdown on
-		 * pending requests that won't be completed due to reset
-		 */
-		nvme_qos_fail_all_queued_requests(dev);
+	if (dev->ctrl.ctrl_config & NVME_CC_ENABLE)
 		nvme_dev_disable(dev, false);
-	}
-
-#else
-
-	if (dev->ctrl.ctrl_config & NVME_CC_ENABLE) {
-		nvme_dev_disable(dev, false);
-	}
-
-#endif
 	nvme_sync_queues(&dev->ctrl);
 
 	mutex_lock(&dev->shutdown_lock);
@@ -4600,13 +4546,6 @@ out_put_ctrl:
 static void nvme_reset_prepare(struct pci_dev *pdev)
 {
 	struct nvme_dev *dev = pci_get_drvdata(pdev);
-#ifdef CONFIG_NVME_QOS
-	/*
-	 * We don't need to check the return value from waiting for the reset
-	 * Fail any queued-but-not-submitted requests before disable
-	 */
-	nvme_qos_fail_all_queued_requests(dev);
-#endif
 	nvme_disable_prepare_reset(dev, false);
 	nvme_sync_queues(&dev->ctrl);
 }

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -2234,6 +2234,11 @@ static void nvme_suspend_queue(struct nvme_dev *dev, unsigned int qid)
 #endif
 
 	nvmeq->dev->online_queues--;
+
+	/* Checks NVMEQ_POLLED status in in nvmeq->flags,
+	 * Checking NVMEQ_ENABLED is not enough because the queue can be disabled but still in polled mode, and we don't want to free irq in that case.
+	 * If the queue is in polled mode, the interrupt is not requested, so we don't need to free it.
+	 */
 	if (!test_and_clear_bit(NVMEQ_POLLED, &nvmeq->flags))
 		pci_free_irq(to_pci_dev(dev->dev), nvmeq->cq_vector, nvmeq);
 }

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -2160,20 +2160,6 @@ disable:
 
 static void nvme_free_queue(struct nvme_queue *nvmeq)
 {
-#ifdef CONFIG_NVME_QOS
-	unsigned long flags;
-
-	/*
-	 * If QoS is enabled, queued-but-not-submitted requests must be drained
-	 * (requeued/failed) before freeing queue memory.  At this point the
-	 * lists should be empty.
-	 */
-	spin_lock_irqsave(&nvmeq->sq_lock, flags);
-	WARN_ON(!list_empty(&nvmeq->high_prio_list));
-	WARN_ON(!list_empty(&nvmeq->normal_prio_list));
-	spin_unlock_irqrestore(&nvmeq->sq_lock, flags);
-#endif
-
 	dma_free_coherent(nvmeq->dev->dev, CQ_SIZE(nvmeq),
 				(void *)nvmeq->cqes, nvmeq->cq_dma_addr);
 	if (!nvmeq->sq_cmds)
@@ -2234,11 +2220,6 @@ static void nvme_suspend_queue(struct nvme_dev *dev, unsigned int qid)
 #endif
 
 	nvmeq->dev->online_queues--;
-
-	/* Checks NVMEQ_POLLED status in in nvmeq->flags,
-	 * Checking NVMEQ_ENABLED is not enough because the queue can be disabled but still in polled mode, and we don't want to free irq in that case.
-	 * If the queue is in polled mode, the interrupt is not requested, so we don't need to free it.
-	 */
 	if (!test_and_clear_bit(NVMEQ_POLLED, &nvmeq->flags))
 		pci_free_irq(to_pci_dev(dev->dev), nvmeq->cq_vector, nvmeq);
 }

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -4546,6 +4546,7 @@ out_put_ctrl:
 static void nvme_reset_prepare(struct pci_dev *pdev)
 {
 	struct nvme_dev *dev = pci_get_drvdata(pdev);
+
 	/*
 	 * We don't need to check the return value from waiting for the reset
 	 * state as pci_dev device lock is held, making it impossible to race

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -1269,6 +1269,54 @@ static void nvme_qos_drain_all_queues(struct nvme_dev *dev)
 			 total);
 }
 
+/*
+ * Queued nut not submitted requests need to be failed during the
+ * controller reset/queue reinit for consistent request handling
+*/
+
+static void nvme_qos_fail_queued_requests(struct nvme_queue *nvmeq){
+	
+	LIST_HEAD(local);
+	// Move all pending requests from the queue to a local list to minimize lock hold time
+	struct request *req;
+	unsigned long flags;
+
+	// Process high priority list and low priority list
+	sin_lock_irqsave(&nvmeq->sq_lock, flags);
+	list_splice_init(&nvmeq->high_prio_list, &local);
+	list_splice_init(&nvmeq->normal_prio_list, &local);
+	spin_unlock_irqrestore(&nvmeq->sq_lock, flags);
+
+	while (!list_empty(&local)){
+		req = list_first_entry(&local, struct request, queuelist);
+		list_del_init(&req->queuelist);
+		nvme_req(req)->status = NVME_SC_HOST_ABORTED_CMD;
+		nvme_req(req)->flags |= NVME_REQ_COMPLETE;
+		blk_mq_complete_request(req);
+	}
+}
+
+/*
+ * Fail queued but not submitted requests from the queues
+ * Called during the controller reset/queue reinit for consistent request handling
+*/
+
+static void nvme_qos_fail_all_queued_requests(struct nvme_dev *dev){
+	unsigned int i;
+
+	// Process all queues
+	for (i = 0; i < dev->ctrl.queue_count; i++){
+
+		// Obtain the queue structure for the current queue index
+		struct nvme_queue *nvmeq = &dev->queues[i];
+
+		if (!nvmeq->sq_cmds)
+			continue; // Skip queues that are not initialized
+
+		nvme_qos_fail_queued_requests(nvmeq);
+	}
+}
+
 #define NVME_QOS_MAX_BATCH 4
 
 static bool nvme_qos_is_high_prio(struct request *req)
@@ -2129,6 +2177,14 @@ static void nvme_free_queues(struct nvme_dev *dev, int lowest)
 {
 	int i;
 
+#ifdef CONFIG_NVME_QOS
+	for (i = dev->ctrl.queue_count - 1; i >= lowest; i--){
+		struct nvme_queue *nvmeq = &dev->queues[i];
+		if (nvmeq->sq_cmds)
+			nvme_qos_cleanup_queue(nvmeq);
+	}
+#endif
+
 	for (i = dev->ctrl.queue_count - 1; i >= lowest; i--) {
 		dev->ctrl.queue_count--;
 		nvme_free_queue(&dev->queues[i]);
@@ -2144,6 +2200,12 @@ static void nvme_suspend_queue(struct nvme_dev *dev, unsigned int qid)
 
 	/* ensure that nvme_queue_rq() sees NVMEQ_ENABLED cleared */
 	mb();
+
+#ifdef CONFIG_NVME_QOS
+
+	// Fail queded but not submitted requests before suspending to avoid stalling on a frozen queue
+	nvme_qos_fail_queued_requests(nvmeq);
+#endif
 
 	nvmeq->dev->online_queues--;
 	if (!nvmeq->qid && nvmeq->dev->ctrl.admin_q)
@@ -3588,8 +3650,16 @@ static void nvme_reset_work(struct work_struct *work)
 	 * If we're called to reset a live controller first shut it down before
 	 * moving on.
 	 */
-	if (dev->ctrl.ctrl_config & NVME_CC_ENABLE)
+	if (dev->ctrl.ctrl_config & NVME_CC_ENABLE) {
+
+#ifdef CONFIG_NVME_QOS
+
+		// Fail any queued requests before disable to avoid blocking shutdown on
+		// pending requests that won't be completed due to reset
+		nvme_qos_fail_all_queued_requests(dev);
+#endif
 		nvme_dev_disable(dev, false);
+	}
 	nvme_sync_queues(&dev->ctrl);
 
 	mutex_lock(&dev->shutdown_lock);
@@ -4023,9 +4093,9 @@ static void nvme_reset_prepare(struct pci_dev *pdev)
 
 	/*
 	 * We don't need to check the return value from waiting for the reset
-	 * state as pci_dev device lock is held, making it impossible to race
-	 * with ->remove().
-	 */
+	/* Fail any queued-but-not-submitted requests before disable */
+	nvme_qos_fail_all_queued_requests(dev);
+#endif
 	nvme_disable_prepare_reset(dev, false);
 	nvme_sync_queues(&dev->ctrl);
 }

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -1291,7 +1291,7 @@ static void nvme_qos_fail_queued_requests(struct nvme_queue *nvmeq)
 		req = list_first_entry(&local, struct request, queuelist);
 		list_del_init(&req->queuelist);
 		nvme_req(req)->status = NVME_SC_HOST_ABORTED_CMD;
-		nvme_req(req)->flags |= NVME_REQ_COMPLETE;
+		nvme_req(req)->flags |= NVME_REQ_CANCELLED;
 		blk_mq_complete_request(req);
 	}
 }
@@ -2160,6 +2160,20 @@ disable:
 
 static void nvme_free_queue(struct nvme_queue *nvmeq)
 {
+#ifdef CONFIG_NVME_QOS
+	unsigned long flags;
+
+	/*
+	 * If QoS is enabled, queued-but-not-submitted requests must be drained
+	 * (requeued/failed) before freeing queue memory.  At this point the
+	 * lists should be empty.
+	 */
+	spin_lock_irqsave(&nvmeq->sq_lock, flags);
+	WARN_ON(!list_empty(&nvmeq->high_prio_list));
+	WARN_ON(!list_empty(&nvmeq->normal_prio_list));
+	spin_unlock_irqrestore(&nvmeq->sq_lock, flags);
+#endif
+
 	dma_free_coherent(nvmeq->dev->dev, CQ_SIZE(nvmeq),
 				(void *)nvmeq->cqes, nvmeq->cq_dma_addr);
 	if (!nvmeq->sq_cmds)
@@ -2178,13 +2192,22 @@ static void nvme_free_queues(struct nvme_dev *dev, int lowest)
 {
 	int i;
 
-#ifdef CONFIG_NVME_QOS
 	for (i = dev->ctrl.queue_count - 1; i >= lowest; i--) {
 		struct nvme_queue *nvmeq = &dev->queues[i];
+
+#ifdef CONFIG_NVME_QOS
+		/*
+		 * Requests queued in the QoS lists haven't been submitted to HW
+		 * yet, so they won't be handled by nvme_cancel_request().  Fail
+		 * them explicitly before freeing queue memory.
+		 */
 		if (nvmeq->sq_cmds)
-			nvme_qos_cleanup_queue(nvmeq);
-	}
+			nvme_qos_fail_queued_requests(nvmeq);
 #endif
+
+		dev->ctrl.queue_count--;
+		nvme_free_queue(nvmeq);
+	}
 }
 
 static void nvme_suspend_queue(struct nvme_dev *dev, unsigned int qid)
@@ -2197,8 +2220,13 @@ static void nvme_suspend_queue(struct nvme_dev *dev, unsigned int qid)
 	/* ensure that nvme_queue_rq() sees NVMEQ_ENABLED cleared */
 	mb();
 
-#ifdef CONFIG_NVME_QOS
+	/*
+	 * Quiesce admin queue before completing any QoS-queued requests from it.
+	 */
+	if (!nvmeq->qid && nvmeq->dev->ctrl.admin_q)
+		nvme_quiesce_admin_queue(&nvmeq->dev->ctrl);
 
+#ifdef CONFIG_NVME_QOS
 	/* Fail queued but not submitted requests before
 	 * suspending to avoid stalling on a frozen queue
 	 */
@@ -2206,8 +2234,6 @@ static void nvme_suspend_queue(struct nvme_dev *dev, unsigned int qid)
 #endif
 
 	nvmeq->dev->online_queues--;
-	if (!nvmeq->qid && nvmeq->dev->ctrl.admin_q)
-		nvme_quiesce_admin_queue(&nvmeq->dev->ctrl);
 	if (!test_and_clear_bit(NVMEQ_POLLED, &nvmeq->flags))
 		pci_free_irq(to_pci_dev(dev->dev), nvmeq->cq_vector, nvmeq);
 }

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -1343,8 +1343,8 @@ static void nvme_qos_drain_all_queues(struct nvme_dev *dev)
 }
 
 /*
- * Queued but not submitted requests need to be failed during the
- * controller reset/queue reinit for consistent request handling
+ * QoS-staged requests are unlinked during queue suspend/free paths;
+ * request completion is handled by the normal NVMe cancel flow.
  */
 
 static bool nvme_qos_is_high_prio(struct request *req)

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -1301,15 +1301,14 @@ static void nvme_qos_fail_queued_requests(struct nvme_queue *nvmeq)
 /*
  * Fail queued but not submitted requests from the queues
  * Called during the controller reset/queue reinit for consistent request handling
-*/
+ */
 
 static void nvme_qos_fail_all_queued_requests(struct nvme_dev *dev)
 {
 	unsigned int i;
 
 	/* Process all queues */
-	for (i = 0; i < dev->ctrl.queue_count; i++)
-	{
+	for (i = 0; i < dev->ctrl.queue_count; i++){
 
 		/* Obtain the queue structure for the current queue index */
 		struct nvme_queue *nvmeq = &dev->queues[i];
@@ -2182,16 +2181,14 @@ static void nvme_free_queues(struct nvme_dev *dev, int lowest)
 	int i;
 
 #ifdef CONFIG_NVME_QOS
-	for (i = dev->ctrl.queue_count - 1; i >= lowest; i--)
-	{
+	for (i = dev->ctrl.queue_count - 1; i >= lowest; i--) {
 		struct nvme_queue *nvmeq = &dev->queues[i];
 		if (nvmeq->sq_cmds)
 			nvme_qos_cleanup_queue(nvmeq);
 	}
 #endif
 
-	for (i = dev->ctrl.queue_count - 1; i >= lowest; i--)
-	{
+	for (i = dev->ctrl.queue_count - 1; i >= lowest; i--) {
 		dev->ctrl.queue_count--;
 		nvme_free_queue(&dev->queues[i]);
 	}

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -1272,11 +1272,10 @@ static void nvme_qos_drain_all_queues(struct nvme_dev *dev)
 /*
  * Queued but not submitted requests need to be failed during the
  * controller reset/queue reinit for consistent request handling
-*/
+ */
 
 static void nvme_qos_fail_queued_requests(struct nvme_queue *nvmeq)
 {
-	
 	LIST_HEAD(local);
 	/* Move all pending requests from the queue to a local list to minimize lock hold time */
 	struct request *req;
@@ -1288,8 +1287,7 @@ static void nvme_qos_fail_queued_requests(struct nvme_queue *nvmeq)
 	list_splice_init(&nvmeq->normal_prio_list, &local);
 	spin_unlock_irqrestore(&nvmeq->sq_lock, flags);
 
-	while (!list_empty(&local))
-	{
+	while (!list_empty(&local)) {
 		req = list_first_entry(&local, struct request, queuelist);
 		list_del_init(&req->queuelist);
 		nvme_req(req)->status = NVME_SC_HOST_ABORTED_CMD;
@@ -1308,7 +1306,7 @@ static void nvme_qos_fail_all_queued_requests(struct nvme_dev *dev)
 	unsigned int i;
 
 	/* Process all queues */
-	for (i = 0; i < dev->ctrl.queue_count; i++){
+	for (i = 0; i < dev->ctrl.queue_count; i++) {
 
 		/* Obtain the queue structure for the current queue index */
 		struct nvme_queue *nvmeq = &dev->queues[i];
@@ -2206,7 +2204,9 @@ static void nvme_suspend_queue(struct nvme_dev *dev, unsigned int qid)
 
 #ifdef CONFIG_NVME_QOS
 
-	/* Fail queued but not submitted requests before suspending to avoid stalling on a frozen queue */
+	/* Fail queued but not submitted requests before
+	 * suspending to avoid stalling on a frozen queue
+	 */
 	nvme_qos_fail_queued_requests(nvmeq);
 #endif
 
@@ -3658,8 +3658,8 @@ static void nvme_reset_work(struct work_struct *work)
 #ifdef CONFIG_NVME_QOS
 
 		/* Fail any queued requests before disable to avoid blocking shutdown on
-		* pending requests that won't be completed due to reset
-		*/
+		 * pending requests that won't be completed due to reset
+		 */
 		nvme_qos_fail_all_queued_requests(dev);
 #endif
 		nvme_dev_disable(dev, false);

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -1270,24 +1270,26 @@ static void nvme_qos_drain_all_queues(struct nvme_dev *dev)
 }
 
 /*
- * Queued nut not submitted requests need to be failed during the
+ * Queued but not submitted requests need to be failed during the
  * controller reset/queue reinit for consistent request handling
 */
 
-static void nvme_qos_fail_queued_requests(struct nvme_queue *nvmeq){
+static void nvme_qos_fail_queued_requests(struct nvme_queue *nvmeq)
+{
 	
 	LIST_HEAD(local);
-	// Move all pending requests from the queue to a local list to minimize lock hold time
+	/* Move all pending requests from the queue to a local list to minimize lock hold time */
 	struct request *req;
 	unsigned long flags;
 
-	// Process high priority list and low priority list
+	/* Process high priority list and low priority list */
 	sin_lock_irqsave(&nvmeq->sq_lock, flags);
 	list_splice_init(&nvmeq->high_prio_list, &local);
 	list_splice_init(&nvmeq->normal_prio_list, &local);
 	spin_unlock_irqrestore(&nvmeq->sq_lock, flags);
 
-	while (!list_empty(&local)){
+	while (!list_empty(&local))
+	{
 		req = list_first_entry(&local, struct request, queuelist);
 		list_del_init(&req->queuelist);
 		nvme_req(req)->status = NVME_SC_HOST_ABORTED_CMD;
@@ -1301,17 +1303,19 @@ static void nvme_qos_fail_queued_requests(struct nvme_queue *nvmeq){
  * Called during the controller reset/queue reinit for consistent request handling
 */
 
-static void nvme_qos_fail_all_queued_requests(struct nvme_dev *dev){
+static void nvme_qos_fail_all_queued_requests(struct nvme_dev *dev)
+{
 	unsigned int i;
 
-	// Process all queues
-	for (i = 0; i < dev->ctrl.queue_count; i++){
+	/* Process all queues */
+	for (i = 0; i < dev->ctrl.queue_count; i++)
+	{
 
-		// Obtain the queue structure for the current queue index
+		/* Obtain the queue structure for the current queue index */
 		struct nvme_queue *nvmeq = &dev->queues[i];
 
 		if (!nvmeq->sq_cmds)
-			continue; // Skip queues that are not initialized
+			continue; /* Skip queues that are not initialized */
 
 		nvme_qos_fail_queued_requests(nvmeq);
 	}
@@ -2178,14 +2182,16 @@ static void nvme_free_queues(struct nvme_dev *dev, int lowest)
 	int i;
 
 #ifdef CONFIG_NVME_QOS
-	for (i = dev->ctrl.queue_count - 1; i >= lowest; i--){
+	for (i = dev->ctrl.queue_count - 1; i >= lowest; i--)
+	{
 		struct nvme_queue *nvmeq = &dev->queues[i];
 		if (nvmeq->sq_cmds)
 			nvme_qos_cleanup_queue(nvmeq);
 	}
 #endif
 
-	for (i = dev->ctrl.queue_count - 1; i >= lowest; i--) {
+	for (i = dev->ctrl.queue_count - 1; i >= lowest; i--)
+	{
 		dev->ctrl.queue_count--;
 		nvme_free_queue(&dev->queues[i]);
 	}
@@ -2203,7 +2209,7 @@ static void nvme_suspend_queue(struct nvme_dev *dev, unsigned int qid)
 
 #ifdef CONFIG_NVME_QOS
 
-	// Fail queded but not submitted requests before suspending to avoid stalling on a frozen queue
+	/* Fail queued but not submitted requests before suspending to avoid stalling on a frozen queue */
 	nvme_qos_fail_queued_requests(nvmeq);
 #endif
 
@@ -3009,8 +3015,8 @@ static ssize_t qos_enable_store(struct device *dev, struct device_attribute *att
 
 	/* When disabling QoS, drain pending requests first */
 	if (!enable && ndev->qos_enabled) {
-		// Set flag first to prevent new enqueues and
-		// ensure flag visible before drain
+		/* Set flag first to prevent new enqueues and */
+		/* ensure flag visible before drain */
 		WRITE_ONCE(ndev->qos_enabled, 0);
 		smp_mb();
 		nvme_qos_drain_all_queues(ndev);
@@ -3654,8 +3660,9 @@ static void nvme_reset_work(struct work_struct *work)
 
 #ifdef CONFIG_NVME_QOS
 
-		// Fail any queued requests before disable to avoid blocking shutdown on
-		// pending requests that won't be completed due to reset
+		/* Fail any queued requests before disable to avoid blocking shutdown on
+		* pending requests that won't be completed due to reset
+		*/
 		nvme_qos_fail_all_queued_requests(dev);
 #endif
 		nvme_dev_disable(dev, false);
@@ -4093,7 +4100,8 @@ static void nvme_reset_prepare(struct pci_dev *pdev)
 
 	/*
 	 * We don't need to check the return value from waiting for the reset
-	/* Fail any queued-but-not-submitted requests before disable */
+	 * Fail any queued-but-not-submitted requests before disable
+	 */
 	nvme_qos_fail_all_queued_requests(dev);
 #endif
 	nvme_disable_prepare_reset(dev, false);

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -2185,11 +2185,6 @@ static void nvme_free_queues(struct nvme_dev *dev, int lowest)
 			nvme_qos_cleanup_queue(nvmeq);
 	}
 #endif
-
-	for (i = dev->ctrl.queue_count - 1; i >= lowest; i--) {
-		dev->ctrl.queue_count--;
-		nvme_free_queue(&dev->queues[i]);
-	}
 }
 
 static void nvme_suspend_queue(struct nvme_dev *dev, unsigned int qid)
@@ -3653,17 +3648,24 @@ static void nvme_reset_work(struct work_struct *work)
 	 * If we're called to reset a live controller first shut it down before
 	 * moving on.
 	 */
-	if (dev->ctrl.ctrl_config & NVME_CC_ENABLE) {
-
 #ifdef CONFIG_NVME_QOS
+
+	if (dev->ctrl.ctrl_config & NVME_CC_ENABLE) {
 
 		/* Fail any queued requests before disable to avoid blocking shutdown on
 		 * pending requests that won't be completed due to reset
 		 */
 		nvme_qos_fail_all_queued_requests(dev);
-#endif
 		nvme_dev_disable(dev, false);
 	}
+
+#else
+
+	if (dev->ctrl.ctrl_config & NVME_CC_ENABLE) {
+		nvme_dev_disable(dev, false);
+	}
+
+#endif
 	nvme_sync_queues(&dev->ctrl);
 
 	mutex_lock(&dev->shutdown_lock);
@@ -4094,7 +4096,7 @@ out_put_ctrl:
 static void nvme_reset_prepare(struct pci_dev *pdev)
 {
 	struct nvme_dev *dev = pci_get_drvdata(pdev);
-
+#ifdef CONFIG_NVME_QOS
 	/*
 	 * We don't need to check the return value from waiting for the reset
 	 * Fail any queued-but-not-submitted requests before disable

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -1282,7 +1282,7 @@ static void nvme_qos_fail_queued_requests(struct nvme_queue *nvmeq)
 	unsigned long flags;
 
 	/* Process high priority list and low priority list */
-	sin_lock_irqsave(&nvmeq->sq_lock, flags);
+	spin_lock_irqsave(&nvmeq->sq_lock, flags);
 	list_splice_init(&nvmeq->high_prio_list, &local);
 	list_splice_init(&nvmeq->normal_prio_list, &local);
 	spin_unlock_irqrestore(&nvmeq->sq_lock, flags);

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -4546,6 +4546,11 @@ out_put_ctrl:
 static void nvme_reset_prepare(struct pci_dev *pdev)
 {
 	struct nvme_dev *dev = pci_get_drvdata(pdev);
+	/*
+	 * We don't need to check the return value from waiting for the reset
+	 * state as pci_dev device lock is held, making it impossible to race
+	 * with ->remove().
+	 */
 	nvme_disable_prepare_reset(dev, false);
 	nvme_sync_queues(&dev->ctrl);
 }


### PR DESCRIPTION
- Adding nvme_qos_fail_queued_requests() to drain and fail requests that are both high and low priority
- Use list_splice_init() atomically claiming list contents under sq_lock, then release to avoid deadlock
- Ensure new requests can't be enqueued before the drain calling nvme_qos_fail_queued_requests() after calling NVMEQ_ENABLED
- Added drain loop in nvme_free_queue() to handle queues that were submitted but not brought online
- Call nvme_qos_fail_all_queued_requests() before nvme_dev_disable() as defense-in-depth. The drain in nvme_suspend_queue() covers any requests enqueued between the reset trigger and queue suspension