### PR TITLE
Eliminate QoS branch overhead via static keys

### DIFF
--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -1683,8 +1683,7 @@ static void nvme_qos_submit_batch(struct nvme_queue *nvmeq,
 	}
 
 	/* Re-check under lock to handle disable race */
-	if (!static_branch_unlikely(&nvme_qos_active) ||
-		unlikely(!READ_ONCE(nvmeq->dev->qos_enabled))) {
+	if (unlikely(!READ_ONCE(nvmeq->dev->qos_enabled))) {
 		while ((req = rq_list_pop(rqlist))) {
 			struct nvme_iod *iod = blk_mq_rq_to_pdu(req);
 
@@ -1732,8 +1731,8 @@ static void nvme_queue_rqs(struct rq_list *rqlist)
 #ifdef CONFIG_NVME_QOS
 		if (nvmeq && nvmeq != req->mq_hctx->driver_data) {
 			if (static_branch_unlikely(&nvme_qos_active) &&
-			nvmeq->dev->qos_enabled &&
-			    !nvme_qos_in_bypass(nvmeq))
+				nvmeq->dev->qos_enabled &&
+				!nvme_qos_in_bypass(nvmeq))
 				nvme_qos_submit_batch(nvmeq, &submit_list);
 			else
 				nvme_submit_cmds(nvmeq, &submit_list);


### PR DESCRIPTION
Close #72

# Motivation
When CONFIG_NVME_QOS is enabled, the fast paths (nvme_queue_rq, nvme_queue_rqs, nvme_qos_kick) evaluate dev->qos_enabled on every I/O submission. For users who compile in QoS support but do not actively enable it via sysfs, this introduces an unnecessary memory load, comparison, and conditional branch for every I/O.

# Solution
This patch introduces a global static key (nvme_qos_active) to provide a true zero-overhead bypass when QoS is globally disabled. By leveraging Linux's jump label infrastructure, the CPU executes a simple NOP instruction on the fast path instead of a conditional branch, yielding better instruction cache utilization and zero per-I/O cost.

Implementation Details:
- Defined nvme_qos_active static key, defaulting to false.
- Added nvme_qos_sysfs_lock to serialize sysfs writes and safely balance the static branch reference counts (static_branch_inc / static_branch_dec).
- Updated the qos_enable_store sysfs endpoint to patch the kernel instructions dynamically when the first device enables QoS or the last device disables it.
- Modified the hot paths (nvme_queue_rq, nvme_queue_rqs, nvme_qos_kick, nvme_qos_submit_batch) to check static_branch_unlikely(&nvme_qos_active) before falling back to the per-device check.
- Added a cleanup step in nvme_remove to decrement the static key reference if a device is hot-unplugged or unbound while its QoS state is active, preventing permanent lock-in of the JMP instructions.