### PR TITLE
Drain priority lists on device teardown

### DIFF
--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -1252,6 +1252,39 @@ static int nvme_qos_drain_queue_locked(struct nvme_queue *nvmeq)
 }
 
 /*
+ * Unlink pending QoS requests from priority lists without submitting.
+ * Called with sq_lock held.
+ */
+static void nvme_qos_purge_queue_locked(struct nvme_queue *nvmeq)
+{
+	struct request *req, *tmp;
+
+	list_for_each_entry_safe(req, tmp, &nvmeq->high_prio_list, queuelist)
+		list_del_init(&req->queuelist);
+
+	list_for_each_entry_safe(req, tmp, &nvmeq->normal_prio_list, queuelist)
+		list_del_init(&req->queuelist);
+}
+
+/*
+ * Unlink all QoS-staged requests from I/O queues during device teardown.
+ * Must be called after queues are suspended, before nvme_cancel_tagset().
+ */
+static void nvme_qos_teardown_queues(struct nvme_dev *dev)
+{
+	unsigned int i;
+
+	for (i = 1; i < dev->ctrl.queue_count; i++) {
+		struct nvme_queue *nvmeq = &dev->queues[i];
+		unsigned long flags;
+
+		spin_lock_irqsave(&nvmeq->sq_lock, flags);
+		nvme_qos_purge_queue_locked(nvmeq);
+		spin_unlock_irqrestore(&nvmeq->sq_lock, flags);
+	}
+}
+
+/*
  * Drain all pending QoS requests from all I/O queues.
  * Called when QoS is disabled at runtime.
  */
@@ -2477,9 +2510,9 @@ static void nvme_init_queue(struct nvme_queue *nvmeq, u16 qid)
 	/*
 	 * Reset QoS state.  After a device reset the old SQ is gone, so
 	 * in_flight must restart at zero.  Any requests that were parked
-	 * on the priority lists have already been cancelled by the
-	 * blk-mq tag-walk in the reset path; reinitialising the list
-	 * heads drops the stale (freed) entries.
+	 * on the priority lists were already explicitly unlinked by
+	 * nvme_qos_teardown_queues() before nvme_cancel_tagset() in the
+	 * disable path, so no stale entries remain here.
 	 */
 	INIT_LIST_HEAD(&nvmeq->high_prio_list);
 	INIT_LIST_HEAD(&nvmeq->normal_prio_list);
@@ -3851,6 +3884,11 @@ static void nvme_dev_disable(struct nvme_dev *dev, bool shutdown)
 	if (pci_is_enabled(pdev))
 		pci_disable_device(pdev);
 	nvme_reap_pending_cqes(dev);
+
+#ifdef CONFIG_NVME_QOS
+	/* Unlink QoS-staged requests; nvme_cancel_tagset() handles completion. */
+	nvme_qos_teardown_queues(dev);
+#endif
 
 	nvme_cancel_tagset(&dev->ctrl);
 	nvme_cancel_admin_tagset(&dev->ctrl);


### PR DESCRIPTION
Closes #50.

When a device is removed or reset, requests sitting in high_prio_list or normal_prio_list that have not yet been submitted to hardware are never unlinked before `nvme_free_queues()` frees the `nvme_queue` memory. This leaves each request's embedded `queuelist` node pointing into freed memory a use after free that KASAN/KFENCE would catch.

Add `nvme_qos_purge_queue_locked()` which walks both lists and calls `list_del_init()` on each entry without touching hardware. Add `nvme_qos_teardown_queues()` which holds `sq_lock` and calls the purge on every allocated I/O queue.
