### PR TITLE
Prevent fake controller reset on timeout of QoS-parked request

### DIFF
--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -2285,8 +2285,8 @@ static enum blk_eh_timer_return nvme_timeout(struct request *req)
 	unsigned long sq_flags;
 
 	spin_lock_irqsave(&nvmeq->sq_lock, sq_flags);
-	if (!list_empty(&req->queuelist)) {
-		list_del_init(&req->queuelist);
+	if (!list_empty(&iod->qos_node)) {
+		list_del_init(&iod->qos_node);
 		if (test_bit(NVMEQ_ENABLED, &nvmeq->flags)) {
 			nvme_sq_submit_cmd(nvmeq, &iod->cmd);
 			nvme_write_sq_db(nvmeq, true);

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -2177,6 +2177,29 @@ static enum blk_eh_timer_return nvme_timeout(struct request *req)
 		goto disable;
 	}
 
+#ifdef CONFIG_NVME_QOS
+	/*
+	 * Timer started before SQ submission; aborting a CID the controller
+	 * never saw would trigger a spurious reset on the second expiry.
+	 * Check under sq_lock rather than gating on qos_enabled: the disable
+	 * path clears that flag before draining the priority lists, so a
+	 * parked request can still be on a list when qos_enabled reads zero.
+	 */
+	unsigned long sq_flags;
+
+	spin_lock_irqsave(&nvmeq->sq_lock, sq_flags);
+	if (!list_empty(&req->queuelist)) {
+		list_del_init(&req->queuelist);
+		if (test_bit(NVMEQ_ENABLED, &nvmeq->flags)) {
+			nvme_sq_submit_cmd(nvmeq, &iod->cmd);
+			nvme_write_sq_db(nvmeq, true);
+			spin_unlock_irqrestore(&nvmeq->sq_lock, sq_flags);
+			return BLK_EH_RESET_TIMER;
+		}
+	}
+	spin_unlock_irqrestore(&nvmeq->sq_lock, sq_flags);
+#endif
+
 	/*
 	 * Did we miss an interrupt?
 	 */


### PR DESCRIPTION
Closes #70.

`nvme_prep_rq()` calls `nvme_start_request()` — starting the blk-mq timeout clock — before the request is placed on a QoS priority list. If the 30 second timer fires while the request is still parked (never written to the SQ), `nvme_timeout()` sends an NVMe abort for a CID the controller has never seen. The controller returns "command not found", `IOD_ABORTED` is set, and the second expiry unconditionally resets the controller.

In `nvme_timeout()`, after the basic device health checks, acquire `sq_lock` and test `!list_empty(&req->queuelist)`. If the request is still parked:
  - Remove it from the priority list unconditionally.
  - If `NVMEQ_ENABLED`: submit directly to the SQ and return `BLK_EH_RESET_TIMER`.
  - If `!NVMEQ_ENABLED`: fall through to the normal timeout path. The controller state will be `RESETTING` or `DELETING` at this point, and the ctrl state switch handles it correctly. The cancel machinery (`nvme_cancel_tagset`) cleans up the request as part of the ongoing disable.
