### PR TITLE
Implement per-namespace QoS opt-in/out toggle

### DIFF
--- a/drivers/nvme/host/core.c
+++ b/drivers/nvme/host/core.c
@@ -4136,6 +4136,7 @@ static void nvme_alloc_ns(struct nvme_ctrl *ctrl, struct nvme_ns_info *info)
 
 #ifdef CONFIG_NVME_QOS
 	ns->qos_policy = NVME_QOS_DEFAULT;
+	ns->qos_enable = NVME_QOS_NS_ENABLE_DEFAULT;
 #endif
 
 	if (nvme_init_ns_head(ns, info))

--- a/drivers/nvme/host/nvme.h
+++ b/drivers/nvme/host/nvme.h
@@ -531,6 +531,8 @@ enum {
 	NVME_QOS_FORCE_HIGH   = 1, /* Treat all traffic as High Priority */
 	NVME_QOS_FORCE_NORMAL = 2, /* Treat all traffic as Normal Priority */
 };
+
+#define NVME_QOS_NS_ENABLE_DEFAULT 1
 #endif
 
 struct nvme_ns {
@@ -560,6 +562,7 @@ struct nvme_ns {
 
 #ifdef CONFIG_NVME_QOS
 	unsigned int qos_policy;
+	unsigned int qos_enable;
 #endif
 };
 

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -1660,6 +1660,13 @@ static blk_status_t nvme_queue_rq(struct blk_mq_hw_ctx *hctx,
 	if (!static_branch_unlikely(&nvme_qos_active) || (dev->qos_enabled == 0))
 		goto direct_submit;
 
+	/* Per-namespace QoS bypass (Issue #36) */
+	if (req->q->queuedata) {
+		struct nvme_ns *ns = req->q->queuedata;
+		if (!READ_ONCE(ns->qos_enable))
+			goto direct_submit;
+	}
+
 	/* Low-depth bypass: skip QoS when no contention */
 	if (nvme_qos_in_bypass(nvmeq))
 		goto direct_submit;
@@ -1751,6 +1758,7 @@ static void nvme_qos_submit_batch(struct nvme_queue *nvmeq,
 {
 	unsigned long flags;
 	struct request *req;
+	bool direct_submitted = false;
 
 	if (rq_list_empty(rqlist))
 		return;
@@ -1778,13 +1786,21 @@ static void nvme_qos_submit_batch(struct nvme_queue *nvmeq,
 
 	while ((req = rq_list_pop(rqlist))) {
 		struct nvme_iod *iod = blk_mq_rq_to_pdu(req);
-		if (nvme_qos_is_high_prio(req))
+		struct nvme_ns *ns = req->q->queuedata;
+
+		if (ns && !READ_ONCE(ns->qos_enable)) {
+			nvme_sq_submit_cmd(nvmeq, &iod->cmd);
+			direct_submitted = true;
+		} else if (nvme_qos_is_high_prio(req)) {
 			list_add_tail(&iod->qos_node, &nvmeq->high_prio_list);
-		else
+		} else {
 			list_add_tail(&iod->qos_node, &nvmeq->normal_prio_list);
+		}
 	}
 
 	nvme_qos_dispatch(nvmeq, true);
+	if (direct_submitted)
+		nvme_write_sq_db(nvmeq, true);
 	spin_unlock_irqrestore(&nvmeq->sq_lock, flags);
 }
 #endif /* CONFIG_NVME_QOS */

--- a/drivers/nvme/host/sysfs.c
+++ b/drivers/nvme/host/sysfs.c
@@ -294,6 +294,30 @@ static ssize_t nvme_qos_policy_store(struct device *dev,
 	return ret;
 }
 static DEVICE_ATTR(qos_policy, S_IRUGO | S_IWUSR, nvme_qos_policy_show, nvme_qos_policy_store);
+
+static ssize_t qos_enable_show(struct device *dev, struct device_attribute *attr,
+			       char *buf)
+{
+	struct gendisk *disk = dev_to_disk(dev);
+	struct nvme_ns *ns = disk->private_data;
+
+	return sysfs_emit(buf, "%u\n", READ_ONCE(ns->qos_enable));
+}
+
+static ssize_t qos_enable_store(struct device *dev, struct device_attribute *attr,
+				const char *buf, size_t count)
+{
+	struct gendisk *disk = dev_to_disk(dev);
+	struct nvme_ns *ns = disk->private_data;
+	unsigned int enable;
+
+	if (kstrtouint(buf, 10, &enable) < 0)
+		return -EINVAL;
+
+	WRITE_ONCE(ns->qos_enable, enable ? 1 : 0);
+	return count;
+}
+static DEVICE_ATTR_RW(qos_enable);
 #endif /* CONFIG_NVME_QOS */
 
 static struct attribute *nvme_ns_attrs[] = {
@@ -307,6 +331,7 @@ static struct attribute *nvme_ns_attrs[] = {
 	&dev_attr_nuse.attr,
 #ifdef CONFIG_NVME_QOS
 	&dev_attr_qos_policy.attr,
+	&dev_attr_qos_enable.attr,
 #endif
 #ifdef CONFIG_NVME_MULTIPATH
 	&dev_attr_ana_grpid.attr,


### PR DESCRIPTION
Close #36

# Summary

This PR implements per-namespace QoS control, allowing individual namespaces to opt out of the NVMe QoS scheduler at runtime.

When a namespace is opted out (`qos_enable == 0`), all of its traffic bypasses the QoS priority lists and is submitted directly to the hardware submission queue, regardless of the bio's `ioprio` or the namespace's `qos_policy`. Pending requests already staged in the priority lists are not stranded and will continue to drain safely.