### PR TITLE
Skip duplicate sq doorbell in `nvme_qos_submit_batch`

### DIFF
--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -1520,9 +1520,10 @@ reset:
  * doorbell once if any requests were submitted and either @commit is true or
  * high prio requested or submission queue wraps around.
  *
+ * Returns true if at least one request was submitted from QoS lists.
  * Must be called with sq_lock held.
  */
-static void nvme_qos_dispatch(struct nvme_queue *nvmeq, bool commit)
+static bool nvme_qos_dispatch(struct nvme_queue *nvmeq, bool commit)
 {
 	unsigned int max_depth = nvmeq->dev->qos_max_depth;
 	unsigned int depth = (max_depth && max_depth < nvmeq->q_depth)
@@ -1553,6 +1554,7 @@ static void nvme_qos_dispatch(struct nvme_queue *nvmeq, bool commit)
 		nvme_write_sq_db(nvmeq, commit || high_prio_submitted);
 
 	nvme_qos_check_enter_bypass(nvmeq);
+	return submitted > 0;
 }
 
 /*
@@ -1759,6 +1761,7 @@ static void nvme_qos_submit_batch(struct nvme_queue *nvmeq,
 	unsigned long flags;
 	struct request *req;
 	bool direct_submitted = false;
+	bool qos_dispatched;
 
 	if (rq_list_empty(rqlist))
 		return;
@@ -1798,8 +1801,8 @@ static void nvme_qos_submit_batch(struct nvme_queue *nvmeq,
 		}
 	}
 
-	nvme_qos_dispatch(nvmeq, true);
-	if (direct_submitted)
+	qos_dispatched = nvme_qos_dispatch(nvmeq, true);
+	if (direct_submitted && !qos_dispatched)
 		nvme_write_sq_db(nvmeq, true);
 	spin_unlock_irqrestore(&nvmeq->sq_lock, flags);
 }


### PR DESCRIPTION
`nvme_qos_submit_batch()` could ring the SQ doorbell twice when a batch contained both direct-submit requests (ns QoS disabled) and QoS-queued requests:

  1. `nvme_qos_dispatch(nvmeq, true)` already rings when it dispatches any QoS work.
  2. The trailing ``if (direct_submitted) nvme_write_sq_db(...)` rang again unconditionally.

  This change makes `nvme_qos_dispatch()` return whether it submitted any QoS-listed requests, and gates the trailing direct-submit doorbell on `direct_submitted && !qos_dispatched`.

  Result:

  - Mixed batches avoid a redundant MMIO doorbell write.
  - Direct-only and QoS-only paths keep existing behavior