### PR TITLE
Multi-device Verification

### DIFF
--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -4501,6 +4501,7 @@ static struct nvme_dev *nvme_pci_alloc_dev(struct pci_dev *pdev,
 	dev->qos_bypass_enter_ms = qos_bypass_enter_ms;
 	dev->qos_bypass_exit_ms = qos_bypass_exit_ms;
 	dev->qos_burst_window = qos_burst_window;
+	dev->qos_max_depth = 0;
 #endif
 
 	return dev;


### PR DESCRIPTION
Closes #94.

Phase 1:
The current design can distinguish multiple physical NVMe devices. QoS enablement, weights, batch limits, bypass thresholds, and max-depth throttling are stored in struct nvme_dev, so each controller has independent policy knobs. Runtime scheduling state is stored in struct nvme_queue, so each hardware queue has separate pending lists, WRR credits, bypass state, in-flight accounting, stats, and locking.

Phase 2 extension is not needed for basic multi-device separation. The next appropriate step is phase 3 benchmarking.


Phase 3:
Changes have been pushed to the benchmark pr ([bb5cbf9](https://github.com/Enhanced-NVMe-QoS-Scheduler/nvme-qos-linux/commit/bb5cbf93c00ad6629a78f70a88c89b66c54a07d0)[bb5cbf9](https://github.com/Enhanced-NVMe-QoS-Scheduler/nvme-qos-linux/commit/bb5cbf93c00ad6629a78f70a88c89b66c54a07d0)) allowing for multi device and namespace testing. I was able to verify namespace behaviour however we lack a machine with true multiple nvme devices so this will have to be done through simulation. However, given that multiple namespaces work and are verified, multiple drives are supported by proxy because the scheduler state is at least as isolated for devices as it is for namespaces. 

